### PR TITLE
Add a parallel Runner

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -130,3 +130,5 @@ dmypy.json
 .idea
 docs/node_modules/*
 *.jsonl
+
+.vscode

--- a/README.md
+++ b/README.md
@@ -53,18 +53,17 @@ and the `data` variable looks like this;
 ```
 
 The nice thing about being able to log results to a file or to the web is that
-you can also more easily parallize your jobs! For example now you can use the `@mempar`
-decorator to parrallelize the function call with [joblib].
+you can also more easily parallize your jobs! For example now you can use the `Runner`
+class to parrallelize the function call with [joblib].
 
 [joblib]: https://joblib.readthedocs.io/en/latest/
 
 ```python
 import numpy as np
-from memo import memlist, memfile, grid, time_taken, mempar
+from memo import memlist, memfile, grid, time_taken, Runner
 
 data = []
 
-@mempar(backend="threading", n_jobs=-1)
 @memfile(filepath="results.jsonl")
 @memlist(data=data)
 @time_taken()
@@ -76,11 +75,9 @@ def birthday_experiment(class_size, n_sim):
     proba = np.mean(n_uniq != class_size)
     return {"est_proba": proba}
 
-g = grid(
-    progbar=False, class_size=[5, 10, 20, 30, 40], n_sim=[1000, 1_000_000, 50, 200]
-)
-
-birthday_experiment(g)
+settings = list(grid(class_size=range(20, 30), n_sim=[100, 10_000, 1_000_000], progbar=False))
+runner = Runner(backend="threading", n_jobs=-1)
+runner.run(func=birthday_experiment, settings=settings, progbar=True)
 ```
 
 ## Features
@@ -91,10 +88,13 @@ This library also offers decorators to pipe to other sources.
 - `memfile` sends the json blobs to a file
 - `memweb` sends the json blobs to a server via http-post requests
 - `memfunc` sends the data to a callable that you supply, like `print`
-- `mempar` parrallelizes function call with joblib
 - `grid` generates a convenient grid for your experiments
 - `random_grid` generates a randomized grid for your experiments
 - `time_taken` also logs the time the function takes to run
+
+And an Option to parallelize function calls using joblib
+
+- `Runner`
 
 Check the API docs [here](https://koaning.github.io/memo/util.html) for more information on
 how these work.

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ This library also offers decorators to pipe to other sources.
 - `random_grid` generates a randomized grid for your experiments
 - `time_taken` also logs the time the function takes to run
 
-And an Option to parallelize function calls using joblib
+And an option to parallelize function calls using joblib.
 
 - `Runner`
 

--- a/demo.py
+++ b/demo.py
@@ -1,3 +1,4 @@
+from memo import Runner
 import numpy as np
 
 from memo import memlist, memfile, grid, time_taken
@@ -19,3 +20,11 @@ def birthday_experiment(class_size, n_sim):
 
 for setting in grid(class_size=range(20, 30), n_sim=[100, 10_000, 1_000_000]):
     birthday_experiment(**setting)
+
+
+# To Run in parallel
+
+
+settings = grid(class_size=range(20, 30), n_sim=[100, 10_000, 1_000_000], progbar=False)
+runner = Runner(backend="threading", n_jobs=-1)
+runner.run(func=birthday_experiment, settings=settings)

--- a/memo/__init__.py
+++ b/memo/__init__.py
@@ -1,6 +1,6 @@
 from ._error import NotInstalled
 from ._grid import grid, random_grid
-from ._base import memlist, memfile, memfunc
+from ._base import memlist, memfile, memfunc, mempar
 from ._util import time_taken
 
 try:
@@ -17,4 +17,5 @@ __all__ = [
     "memfunc",
     "memweb",
     "time_taken",
+    "mempar"
 ]

--- a/memo/__init__.py
+++ b/memo/__init__.py
@@ -1,6 +1,6 @@
 from ._error import NotInstalled
 from ._grid import grid, random_grid
-from ._base import memlist, memfile, memfunc, mempar
+from ._base import memlist, memfile, memfunc, Runner
 from ._util import time_taken
 
 try:
@@ -17,5 +17,5 @@ __all__ = [
     "memfunc",
     "memweb",
     "time_taken",
-    "mempar"
+    "Runner"
 ]

--- a/memo/_base.py
+++ b/memo/_base.py
@@ -8,37 +8,6 @@ import joblib.parallel
 from rich.progress import Progress
 import time
 
-# class BatchCompletionCallBack(object):
-
-#     def __init__(self, dispatch_timestamp, batch_size, parallel):
-#         self.dispatch_timestamp = dispatch_timestamp
-#         self.batch_size = batch_size
-#         self.parallel = parallel
-
-#     def __call__(self, out):
-
-#         self.parallel.n_completed_tasks += self.batch_size
-#         this_batch_duration = time.time() - self.dispatch_timestamp
-
-#         self.parallel._backend.batch_completed(self.batch_size,
-#                                                this_batch_duration)
-#         self.parallel.print_progress()
-#         self._update()
-#         with self.parallel._lock:
-#             if self.parallel._original_iterator is not None:
-#                 self.parallel.dispatch_next()
-
-#     @classmethod
-#     def _setup(cls, total):
-#         cls.total = total
-#         with Progress() as cls.progress:
-#             cls.task = cls.progress.add_task("[red]Mempar....", total=cls.total)
-#             return cls
-
-#     def _update(self):
-#         self.progress.update(self.task, completed=self.parallel.n_completed_tasks / self.total, refresh=True)
-#         # self.progress.refresh()
-
 
 def mempar(*args, progbar=True, **kwargs):
     """Wraps joblib's Parallel for easy parallelization

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup, find_packages
 
-base_packages = ["rich>=9.2.0", "orjson>=3.4.5"]
+base_packages = ["rich>=9.2.0", "orjson>=3.4.5", "joblib>=1.0.1"]
 
 test_packages = [
     "flake8>=3.6.0",

--- a/tests/test_docs.py
+++ b/tests/test_docs.py
@@ -3,10 +3,10 @@ import pathlib
 import pytest
 
 from mktestdocs import check_md_file, check_docstring
-from memo import memlist, memfunc, memfile, time_taken, grid, random_grid
+from memo import memlist, memfunc, memfile, time_taken, grid, random_grid, mempar
 
 files = [str(p) for p in pathlib.Path("docs").glob("*.md")] + ["README.md"]
-functions = [memlist, memfunc, memfile, time_taken, grid, random_grid]
+functions = [memlist, memfunc, memfile, time_taken, grid, random_grid, mempar]
 
 
 @pytest.mark.parametrize("fpath", files)

--- a/tests/test_docs.py
+++ b/tests/test_docs.py
@@ -2,11 +2,12 @@ import pathlib
 
 import pytest
 
-from mktestdocs import check_md_file, check_docstring
-from memo import memlist, memfunc, memfile, time_taken, grid, random_grid, mempar
+from mktestdocs import check_md_file, check_docstring, get_codeblock_members
+from memo import memlist, memfunc, memfile, time_taken, grid, random_grid, Runner
 
 files = [str(p) for p in pathlib.Path("docs").glob("*.md")] + ["README.md"]
-functions = [memlist, memfunc, memfile, time_taken, grid, random_grid, mempar]
+functions = [memlist, memfunc, memfile, time_taken, grid, random_grid]
+classes = [Runner]
 
 
 @pytest.mark.parametrize("fpath", files)
@@ -17,3 +18,8 @@ def test_files_good(fpath):
 @pytest.mark.parametrize("func", functions, ids=lambda d: d.__name__)
 def test_docstrings(func):
     check_docstring(func)
+
+
+@pytest.mark.parametrize("cls", classes)
+def test_class_docstrings(cls):
+    get_codeblock_members(cls)

--- a/tests/test_mempar.py
+++ b/tests/test_mempar.py
@@ -1,0 +1,64 @@
+import pytest
+from memo import memlist, mempar
+
+
+@pytest.mark.parametrize("kw", [{"backend": "loky", "n_jobs": -1}, {"backend": "threading", "n_jobs": -1}, {"backend": "multiprocessing", "n_jobs": -1}])
+def test_base_multiple_calls(kw):
+    data = []
+    g = [{"a": 1}] * 100
+
+    @mempar(**kw)
+    @memlist(data=data)
+    def count_values(**kwargs):
+        return {"sum": sum(kwargs.values())}
+
+    count_values(g)
+    assert len(data) == len(g)
+
+
+@pytest.mark.parametrize("kw", [{"backend": "loky", "n_jobs": -1}, {"backend": "threading", "n_jobs": -1}, {"backend": "multiprocessing", "n_jobs": -1}])
+def test_keys_included(kw):
+    data = []
+    g = [{"a": 3, "b": 4, "c": 5}]
+
+    @mempar(**kw)
+    @memlist(data=data)
+    def count_values(**kwargs):
+        return {"sum": sum(kwargs.values())}
+
+    count_values(g)
+
+    assert len(data) == 1
+    assert all([k in data[0].keys() for k in g[0].keys()])
+
+
+@pytest.mark.parametrize("kw", [{"backend": "loky", "n_jobs": -1}, {"backend": "threading", "n_jobs": -1}, {"backend": "multiprocessing", "n_jobs": -1}])
+def test_base_args_included(kw):
+    data = []
+
+    @mempar(**kw)
+    @memlist(data=data)
+    def count_values(a, b, **kwargs):
+        return {"sum": sum(kwargs.values())}
+
+    count_values([{"a": 1, "b": 2, "c": 1}, {"a": 1, "b": 2, "c": 1}])
+    assert len(data) == 2
+    assert data[0]["a"] == 1
+    assert data[0]["b"] == 2
+    assert data[0]["c"] == 1
+    assert data[1]["a"] == 1
+    assert data[1]["b"] == 2
+    assert data[1]["c"] == 1
+
+
+def test_raises_type_error():
+    data = []
+    g = {"a": 3, "b": 4, "c": 5}
+
+    with pytest.raises(TypeError):
+        @mempar(backend="threading", n_jobs=-1)
+        @memlist(data=data)
+        def count_values(**kwargs):
+            return {"sum": sum(kwargs.values())}
+
+        count_values(g)

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -3,13 +3,13 @@ import warnings
 from memo import memlist, Runner, grid
 
 
-@pytest.mark.parametrize("kw", [{"backend": "loky", "n_jobs": -1}, {"backend": "threading", "n_jobs": -1}, {"backend": "multiprocessing", "n_jobs": -1}])
+@pytest.mark.parametrize("kw", [{"backend": "loky"}, {"backend": "threading"}, {"backend": "multiprocessing"}])
 def test_base_multiple_calls(kw):
     data = []
     g = [{"a": 1}] * 100
 
     @memlist(data=data)
-    def count_values(**kwargs):
+    def count_values(n_jobs=-1, **kwargs):
         return {"sum": sum(kwargs.values())}
 
     runner = Runner(**kw)
@@ -17,7 +17,7 @@ def test_base_multiple_calls(kw):
     assert len(data) == len(g)
 
 
-@pytest.mark.parametrize("kw", [{"backend": "loky", "n_jobs": -1}, {"backend": "threading", "n_jobs": -1}, {"backend": "multiprocessing", "n_jobs": -1}])
+@pytest.mark.parametrize("kw", [{"backend": "loky"}, {"backend": "threading"}, {"backend": "multiprocessing"}])
 def test_keys_included(kw):
     data = []
     g = [{"a": 3, "b": 4, "c": 5}]
@@ -26,13 +26,13 @@ def test_keys_included(kw):
     def count_values(**kwargs):
         return {"sum": sum(kwargs.values())}
 
-    runner = Runner(**kw)
+    runner = Runner(n_jobs=-1, **kw)
     runner.run(func=count_values, settings=g, progbar=True)
     assert len(data) == 1
     assert all([k in data[0].keys() for k in g[0].keys()])
 
 
-@pytest.mark.parametrize("kw", [{"backend": "loky", "n_jobs": -1}, {"backend": "threading", "n_jobs": -1}, {"backend": "multiprocessing", "n_jobs": -1}])
+@pytest.mark.parametrize("kw", [{"backend": "loky"}, {"backend": "threading"}, {"backend": "multiprocessing"}])
 def test_base_args_included(kw):
     data = []
 
@@ -41,7 +41,7 @@ def test_base_args_included(kw):
         return {"sum": sum(kwargs.values())}
 
     g = [{"a": 1, "b": 2, "c": 1}, {"a": 1, "b": 2, "c": 1}]
-    runner = Runner(**kw)
+    runner = Runner(n_jobs=-1, **kw)
     runner.run(func=count_values, settings=g, progbar=True)
     assert len(data) == 2
     assert data[0]["a"] == 1


### PR DESCRIPTION
Hey guys. I love the package it's very useful. I thought I would go ahead and submit this PR. I created a wrapper called `mempar` that uses joblib to parallelize whatever function you would normally wrap with `memlist`. Now you can just pass an iterable of dicts with keys that match the function signature and the function will execute in a parrallel menner. `mempar` also allows for the passage of all positional and keyword arguments to `parallel_backend` .

I also went ahead and created some unit tests based off those in `test_memfile.py` which are now in `test_mempar`. I also tested with the `@memfile` decorator and everything works so long as `@mempar` comes before `@memfile`. I didn't get around to writing a unit test for that specific condition yet.

I hope this adds some more utility to the package. Please let me know if there is anything else you want to know. I tried my best to match formatter, linter, doc style etc... since I didn't find a contribution guide.

-Brad