### PR TITLE
Docs typos and type hints

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ runner.run(func=birthday_experiment, settings=settings, progbar=True)
 
 This library also offers decorators to pipe to other sources.
 
-- `memlists` sends the json blobs to a list
+- `memlist` sends the json blobs to a list
 - `memfile` sends the json blobs to a file
 - `memweb` sends the json blobs to a server via http-post requests
 - `memfunc` sends the data to a callable that you supply, like `print`

--- a/docs/api.md
+++ b/docs/api.md
@@ -5,19 +5,17 @@
         show_root_full_path: false
         show_root_heading: true
 
-
 ::: memo._base.memfile
     rendering:
         show_root_full_path: false
         show_root_heading: true
-
 
 ::: memo._base.memfunc
     rendering:
         show_root_full_path: false
         show_root_heading: true
 
-::: memo.memweb
+::: memo._http.memweb
     rendering:
         show_root_full_path: false
         show_root_heading: true

--- a/docs/index.md
+++ b/docs/index.md
@@ -51,7 +51,7 @@ check the [quickstart](https://koaning.github.io/memo/getting-started.html)
 
 This library also offers decorators to pipe to other sources. 
 
-- `memlists` sends the json blobs to a list
+- `memlist` sends the json blobs to a list
 - `memfile` sends the json blobs to a file 
 - `memweb` sends the json blobs to a server via http-post requests
 - `memfunc` sends the data to a callable that you supply, like `print`

--- a/memo/_base.py
+++ b/memo/_base.py
@@ -18,7 +18,7 @@ def _contains(kwargs, datalist):
     return False
 
 
-def memlist(data: List, skip=False):
+def memlist(data: List, skip: bool = False):
     """
     Remembers input/output of a function in python list.
 

--- a/memo/_grid.py
+++ b/memo/_grid.py
@@ -2,7 +2,7 @@ import random
 import itertools as it
 
 
-def grid(shuffle=True, progbar=None, **kwargs):
+def grid(shuffle: bool = True, progbar: bool = None, **kwargs):
     """
     Generates a grid of settings.
 
@@ -36,7 +36,7 @@ def grid(shuffle=True, progbar=None, **kwargs):
     return settings
 
 
-def random_grid(n=30, **kwargs):
+def random_grid(n: int = 30, **kwargs):
     """
     Generates a random grid settings.
 

--- a/memo/_util.py
+++ b/memo/_util.py
@@ -2,7 +2,7 @@ import time
 from functools import wraps
 
 
-def time_taken(minutes=False, rounding=2):
+def time_taken(minutes: bool = False, rounding: int = 2):
     """
     Adds additional time-based information to output.
 


### PR DESCRIPTION
- Fixed typos in the docs (and readme) as in #39.
- Added few type hints which were missing from the codebase.