### PR TITLE
use time.perf_counter instead of time.time

### DIFF
--- a/memo/_util.py
+++ b/memo/_util.py
@@ -40,9 +40,9 @@ def time_taken(minutes: bool = False, rounding: int = 2):
     def decorator(func):
         @wraps(func)
         def wrapper(*args, **kwargs):
-            tic = time.time()
+            tic = time.perf_counter()
             result = func(*args, **kwargs)
-            toc = time.time()
+            toc = time.perf_counter()
             time_total = toc - tic
             if minutes:
                 time_total = time_total / 60


### PR DESCRIPTION
time. perf_counter() uses the processor's performance counter to measure time while time. time() uses the system clock. 

In general, perf_counter() is more precise and has a higher resolution than time() , so it's often the better choice for timing small code blocks or individual statements, and this is recommended by python's builtin time module